### PR TITLE
fix swapped longan_led_on/off - board has LED anode at 3.3v

### DIFF
--- a/examples/longan-nano-blink/src/main.c
+++ b/examples/longan-nano-blink/src/main.c
@@ -53,12 +53,16 @@ void longan_led_init()
 
 void longan_led_on()
 {
-    GPIO_BOP(LED_GPIO_PORT) = LED_PIN;
+    /*
+     * LED is hardwired with 3.3V on the anode, we control the cathode
+     * (negative side) so we need to use reversed logic: bit clear is on.
+     */
+    GPIO_BC(LED_GPIO_PORT) = LED_PIN;
 }
 
 void longan_led_off()
 {
-    GPIO_BC(LED_GPIO_PORT) = LED_PIN;
+    GPIO_BOP(LED_GPIO_PORT) = LED_PIN;
 }
 /*!
     \brief      main function


### PR DESCRIPTION
if we check out the schematic[0] we see that the LEDs are hardwired to 3.3V,
we cannot control the anode only the negative cathode. So writing out a LOW
value to the GPIO port connected with a LED (PC13, PA1, PA2) will make it light
up, and writing out a HIGH value will interrupt current flow and turn the LED off.

In the example this seemed to work as the loop did both, switch on and switch
off, so the swapped logic was seemingly no issue. But if one just test the
following main before my change, they can see that it was broken:

int main(void) {
    longan_led_init();
    longan_led_off(); // LED should be out, but it will light!

    while (1);
}

As people will use this example to start developing their own things,
it really should be correct!

[0]: http://dl.sipeed.com/LONGAN/Nano/HDK/Longan%20Nano%202663/Longan%20nano%202663(Schematic).pdf

Signed-off-by: Thomas Lamprecht <thomas@lamprecht.org>