### PR TITLE
Allow using custom linker scripts

### DIFF
--- a/boards/gd32vf103v-eval.json
+++ b/boards/gd32vf103v-eval.json
@@ -1,13 +1,18 @@
 {
     "build": {
+        "arduino": {
+            "ldscript": "GD32VF103xB.lds"
+        },
         "f_cpu": "108000000L",
+        "gd32vf103-sdk": {
+            "ldscript": "GD32VF103xB.lds"
+        },
         "hwids": [
             [
                 "0x28e9",
                 "0x058f"
             ]
         ],
-        "ldscript": "GD32VF103xB.lds",
         "mabi": "ilp32",
         "march": "rv32imac",
         "mcmodel": "medlow",

--- a/boards/sipeed-longan-nano-lite.json
+++ b/boards/sipeed-longan-nano-lite.json
@@ -1,13 +1,18 @@
 {
     "build": {
+        "arduino": {
+            "ldscript": "GD32VF103x8.lds"
+        },
         "f_cpu": "108000000L",
+        "gd32vf103-sdk": {
+            "ldscript": "GD32VF103x8.lds"
+        },
         "hwids": [
             [
                 "0x28e9",
                 "0x0189"
             ]
         ],
-        "ldscript": "GD32VF103x8.lds",
         "mabi": "ilp32",
         "march": "rv32imac",
         "mcmodel": "medlow",

--- a/boards/sipeed-longan-nano.json
+++ b/boards/sipeed-longan-nano.json
@@ -1,13 +1,18 @@
 {
     "build": {
+        "arduino": {
+            "ldscript": "GD32VF103xB.lds"
+        },
         "f_cpu": "108000000L",
+        "gd32vf103-sdk": {
+            "ldscript": "GD32VF103xB.lds"
+        },
         "hwids": [
             [
                 "0x28e9",
                 "0x0189"
             ]
         ],
-        "ldscript": "GD32VF103xB.lds",
         "mabi": "ilp32",
         "march": "rv32imac",
         "mcmodel": "medlow",

--- a/boards/wio_lite_risc-v.json
+++ b/boards/wio_lite_risc-v.json
@@ -1,13 +1,18 @@
 {
     "build": {
+        "arduino": {
+            "ldscript": "GD32VF103xB.lds"
+        },
         "f_cpu": "108000000L",
+        "gd32vf103-sdk": {
+            "ldscript": "GD32VF103xB.lds"
+        },
         "hwids": [
             [
                 "0x28e9",
                 "0x0189"
             ]
         ],
-        "ldscript": "GD32VF103xB.lds",
         "mabi": "ilp32",
         "march": "rv32imac",
         "mcmodel": "medlow",

--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -13,14 +13,13 @@ SDK_DIR = join(FRAMEWORK_DIR, "cores", "arduino", "GD32VF103_Firmware_Library")
 env.SConscript("_bare.py", exports="env")
 
 env.Append(
-
-    CPPDEFINES = [
+    CPPDEFINES=[
         ("ARDUINO", 10805),
         ("ARDUINO_VARIANT", '\\"%s\\"' % env.BoardConfig().get("build.variant").replace('"', "")),
         ("ARDUINO_BOARD", '\\"%s\\"' % env.BoardConfig().get("build.board_def").replace('"', ""))
     ],
-    
-    CPPPATH = [
+
+    CPPPATH=[
         join(FRAMEWORK_DIR, "cores", "arduino"),
         join(FRAMEWORK_DIR, "cores", "arduino", "deprecated-avr-comp"),
         join(SDK_DIR, "GD32VF103_standard_peripheral"),
@@ -32,19 +31,18 @@ env.Append(
         join(SDK_DIR, "RISCV", "stubs"),
     ],
 
-    LIBS = [
+    LIBS=[
         "c"
     ],
 
     LIBSOURCE_DIRS=[
         join(FRAMEWORK_DIR, "libraries")
     ],
-
 )
 
-env.Replace(
-    LDSCRIPT_PATH = join(SDK_DIR, "RISCV", "env_Eclipse", board.get("build.ldscript")) 
-)
+if not env.BoardConfig().get("build.ldscript", ""):
+    env.Replace(LDSCRIPT_PATH=join(
+        SDK_DIR, "RISCV", "env_Eclipse", board.get("build.arduino.ldscript")))
 
 #
 # Target: Build Core Library

--- a/builder/frameworks/firmware_library.py
+++ b/builder/frameworks/firmware_library.py
@@ -12,8 +12,7 @@ assert FRAMEWORK_DIR and isdir(FRAMEWORK_DIR)
 env.SConscript("_bare.py", exports="env")
 
 env.Append(
-
-    CPPPATH = [
+    CPPPATH=[
         join(FRAMEWORK_DIR, "GD32VF103_standard_peripheral"),
         join(FRAMEWORK_DIR, "GD32VF103_standard_peripheral", "Include"),
         join(FRAMEWORK_DIR, "GD32VF103_usbfs_driver"),
@@ -23,17 +22,17 @@ env.Append(
         join(FRAMEWORK_DIR, "RISCV", "stubs"),
     ],
 
-    LIBS = [
+    LIBS=[
         "c"
     ]
 
 )
 
-
-
-env.Replace(
-    LDSCRIPT_PATH = join(FRAMEWORK_DIR, "RISCV", "env_Eclipse", board.get("build.ldscript")) 
-)
+if not env.BoardConfig().get("build.ldscript", ""):
+    env.Replace(
+        LDSCRIPT_PATH=join(FRAMEWORK_DIR, "RISCV", "env_Eclipse", board.get(
+            "build.gd32vf103-sdk.ldscript"))
+    )
 
 #
 # Target: Build Core Library
@@ -47,7 +46,7 @@ libs = [
 #    env.BuildLibrary(
 #        join("$BUILD_DIR", "usbfs_driver"),
 #        join(FRAMEWORK_DIR, "GD32VF103_usbfs_driver")),
-    
+
     env.BuildLibrary(
         join("$BUILD_DIR", "RISCV"),
         join(FRAMEWORK_DIR, "RISCV")),
@@ -57,7 +56,7 @@ libs = [
 env.Prepend(LIBS=libs)
 
 # if board.get("name") == "GD32VF103V-EVAL":
-    
+
 #     env.Prepend(
 #         CPPPATH = [
 #             join(FRAMEWORK_DIR, "Utilities"),
@@ -72,4 +71,3 @@ env.Prepend(LIBS=libs)
 #     ]
 
 #     env.Prepend(LIBS=libs)
-


### PR DESCRIPTION
This will allow users to specify any linker script from `platformio.ini` file using the following syntax:
```ini
[env:sipeed-longan-nano]
platform = gd32v
framework = gd32vf103-sdk
board = sipeed-longan-nano

board_build.ldscript = custom_ldscript.ld
```
This is a more correct way of specifying it in comparison with using the `-Wl,-T` flag.