### PR TITLE
Fix issue #28 "tool-dfuutil not auto-installed"

### DIFF
--- a/platform.py
+++ b/platform.py
@@ -2,6 +2,16 @@ from platformio.managers.platform import PlatformBase
 
 class Gd32vPlatform(PlatformBase):
 
+    def configure_default_packages(self, variables, targets):
+        board = variables.get("board")
+        board_config = self.board_config(board)
+
+        default_protocol = board_config.get("upload.protocol") or ""
+        if variables.get("upload_protocol", default_protocol) == "dfu":
+            self.packages["tool-dfuutil"]["optional"] = False
+
+        return PlatformBase.configure_default_packages(self, variables, targets)
+    
     def get_boards(self, id_=None):
         result = PlatformBase.get_boards(self, id_)
         if not result:


### PR DESCRIPTION
The tool-dfuutil dependency is declared as optional in platform.json. The problem is it never gets installed, even when using DFU as upload protocol. This patch makes tool-dfuutil required when using DFU, and leaves it optional otherwise.