### PR TITLE
Updated used dfu-util to latest version available

### DIFF
--- a/platform.json
+++ b/platform.json
@@ -73,7 +73,7 @@
             "type": "uploader",
             "optional": true,
             "owner": "platformio",
-            "version": "~1.9.200310"
+            "version": "~1.11.0"
         }
     }
 


### PR DESCRIPTION
Platformio now has dfu-util 0.11 available in package tool-dfuutil.
See https://registry.platformio.org/tools/platformio/tool-dfuutil